### PR TITLE
Finish PythonCall.jl integration

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,7 +1,7 @@
 [deps]
-numpy = ""
-wandb = ">=0.13"
 python = ">=3.9"
 
 [pip.deps]
+numpy = ""
 pillow = ""
+wandb = ">=0.13"

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,7 +1,5 @@
 [deps]
 numpy = ""
-pillow = ""
 protobuf = "=3"
 python = ">=3.9"
 wandb = ">=0.13"
-

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,7 +1,7 @@
 [deps]
-python = ">=3.9"
-
-[pip.deps]
 numpy = ""
 pillow = ""
+protobuf = "=3"
+python = ">=3.9"
 wandb = ">=0.13"
+

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,5 +1,6 @@
 [deps]
 numpy = ""
+pillow = ""
 protobuf = "=3"
 python = ">=3.9"
 wandb = ">=0.13"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,17 +4,16 @@ makedocs(; sitename="Wandb", authors="Avik Pal",
          format=Documenter.HTML(; prettyurls=get(ENV, "CI", nothing) == "true"),
          modules=[Wandb],
          pages=[
-             "Home" => "index.md",
-             "QuickStart" => "quickstart.md",
-             "Miscellaneous" => "misc.md",
-             "Examples" => [
-                 "Getting Started" => "examples/demo.md",
-                 "Flux.jl Integration" => "examples/flux.md",
-                 "FluxTraining.jl Integration" => "examples/fluxtraining.md",
-                 "HyperParameter Sweeps" => "examples/hparams.md",
-                 "Artifacts API" => "examples/artifacts.md",
-                 "MPI.jl Integration" => "examples/mpi.md",
-             ],
+           "Home" => "index.md",
+           "API Reference" => "api.md",
+           "Examples" => [
+             "Getting Started" => "examples/demo.md",
+             "Flux.jl Intergration" => "examples/flux.md",
+             "FluxTraining.jl Integration" => "examples/fluxtraining.md",
+             "HyperParameter Sweeps" => "examples/hparams.md",
+             "Artifacts API" => "examples/artifacts.md",
+             "MPI.jl Integration" => "examples/mpi.md",
+           ],
          ])
 
 deploydocs(; repo="github.com/avik-pal/Wandb.jl.git", push_preview=true, devbranch="main")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ makedocs(; sitename="Wandb", authors="Avik Pal",
              "Miscellaneous" => "misc.md",
              "Examples" => [
                  "Getting Started" => "examples/demo.md",
-                 "Flux.jl Intergration" => "examples/flux.md",
+                 "Flux.jl Integration" => "examples/flux.md",
                  "FluxTraining.jl Integration" => "examples/fluxtraining.md",
                  "HyperParameter Sweeps" => "examples/hparams.md",
                  "Artifacts API" => "examples/artifacts.md",

--- a/docs/src/examples/flux.md
+++ b/docs/src/examples/flux.md
@@ -15,6 +15,7 @@ using CUDA
 using MLDatasets
 using Wandb
 using Dates
+using Logging
 
 lg = WandbLogger(project = "Wandb.jl", name = "fluxjl-integration-$(now())",
                  config = Dict("learning_rate" => 3e-4, "batchsize" => 256,
@@ -77,7 +78,7 @@ function train(update_params::Dict = Dict())
     #################################
     update_config!(lg, update_params)
 
-    if CUDA.functional() && wandb_get_config("use_cuda")
+    if CUDA.functional() && get_config(lg, "use_cuda")
         @info "Training on CUDA GPU"
         CUDA.allowscalar(false)
         device = gpu
@@ -111,7 +112,7 @@ function train(update_params::Dict = Dict())
         ###################################
         # Wandb # Log the loss and accuracy
         ###################################
-        log(
+        Wandb.log(
             lg,
             Dict(
                 "Training/Loss" => train_loss,

--- a/docs/src/examples/fluxtraining.md
+++ b/docs/src/examples/fluxtraining.md
@@ -2,3 +2,55 @@
 
 We have bindings in the form of `WandbBackend` which can be used as a dropin replacement for the
 default `TensorboardBackend`. Just ensure that `FluxTraining.jl` is installed and loaded explicitly.
+
+Let's go through the
+[FluxTraining.jl MNIST](https://github.com/FluxML/FluxTraining.jl/blob/master/docs/tutorials/mnist.ipynb)
+example and update it to use Wandb.
+
+
+```julia
+using MLUtils: splitobs, unsqueeze
+using MLDatasets: MNIST
+using Flux
+using Flux: onehotbatch
+using Flux.Data: DataLoader
+using FluxTraining
+using Wandb
+
+# import data
+data = MNIST(:train)[:]
+
+const LABELS = 0:9
+
+# unsqueeze to reshape from (28, 28, numobs) to (28, 28, 1, numobs)
+function preprocess((data, targets))
+    return unsqueeze(data, 3), onehotbatch(targets, LABELS)
+end
+
+
+# traindata and testdata contain both inputs (pixel values) and targets (correct labels)
+traindata = MNIST(Float32, :train)[:] |> preprocess
+testdata = MNIST(Float32, :test)[:] |> preprocess
+
+# create iterators
+trainiter, testiter = DataLoader(traindata, batchsize=128), DataLoader(testdata, batchsize=256);
+
+# create model and optimizer
+model = Chain(
+    Conv((3, 3), 1 => 16, relu, pad = 1, stride = 2),
+    Conv((3, 3), 16 => 32, relu, pad = 1),
+    GlobalMeanPool(),
+    Flux.flatten,
+    Dense(32, 10),
+)
+lossfn = Flux.Losses.logitcrossentropy
+optimizer = Flux.ADAM();
+
+# prepare learner
+logwandb = LogMetrics(WandbBackend(project = "Wandb.jl", 
+                                    name = "fluxtrainingjl-integration-$(now())"))
+learner = Learner(model, lossfn; callbacks=[ToGPU(), Metrics(accuracy)], optimizer)
+
+# fit model
+FluxTraining.fit!(learner, 10, (trainiter, testiter))
+```

--- a/docs/src/examples/hparams.md
+++ b/docs/src/examples/hparams.md
@@ -29,6 +29,7 @@ ho = @hyperopt for i = 50, sampler = RandomSampler(), # This is default if none 
     hpsweep(f, Dict("a" => a, "b" => b, "c" => c), project = "Wandb.jl",
             config = Dict("x" => 100))
 end
+
 ```
 
 After this is done, we need to do some manual tweaking in the Wandb UI to get a clean

--- a/docs/src/examples/mpi.md
+++ b/docs/src/examples/mpi.md
@@ -15,7 +15,7 @@ lg = WandbLoggerMPI(project = "Wandb.jl",
 # Step 2: Sync Model Parameters
 model = Chain(Dense(1, 2, tanh), Dense(2, 1)) |> gpu
 ps = Flux.params(model)
-broadcast_parameters(model; root_rank = 0)
+FluxMPI.synchronize!(model; root_rank = 0)
 
 # It is the user's responsibility to partition the data across the processes
 # In this case, we are training on a total of 16 * <np> samples
@@ -25,7 +25,7 @@ dataloader = Flux.DataLoader((x, y), batchsize = 16)
 
 # Step 3: Wrap the optimizer in DistributedOptimizer
 #         Scale the learning rate by the number of workers (`total_workers()`).
-opt = DistributedOptimiser(Flux.ADAM(0.001))
+opt = Flux.ADAM(0.001)
 
 function loss(x_, y_)
     l = sum(abs2, model(x_) .- y_)
@@ -36,6 +36,9 @@ end
 for epoch in 1:100
     Flux.Optimise.train!(loss, ps, dataloader, opt)
 end
+
+# Finish the run
+close(lg)
 ```
 
 The main points when using MPI and Wandb are:

--- a/src/Wandb.jl
+++ b/src/Wandb.jl
@@ -14,9 +14,9 @@ function __init__()
   PythonCall.pycopy!(wandb, pyimport("wandb"))
   PythonCall.pycopy!(numpy, pyimport("numpy"))
 
-  # @require FluxTraining="7bf95e4d-ca32-48da-9824-f0dc5310474f" begin include("fluxtraining.jl") end
+  @require FluxTraining="7bf95e4d-ca32-48da-9824-f0dc5310474f" begin include("fluxtraining.jl") end
 
-  # @require MPI="da04e1cc-30fd-572f-bb4f-1f8673147195" begin include("mpi.jl") end
+  @require MPI="da04e1cc-30fd-572f-bb4f-1f8673147195" begin include("mpi.jl") end
 
   return
 end

--- a/src/main.jl
+++ b/src/main.jl
@@ -128,7 +128,8 @@ Image(img::String; kwargs...) = wandb.Image(img; kwargs...)
 Image(img::IO; kwargs...) = wandb.Image(pytextio(img); kwargs...)
 
 function Image(img::Any; kwargs...)
-  for (mime, ext) in ((MIME"image/png"(), "png"), (MIME"image/jpeg"(), "jpg"))
+  mime_pairs = ((MIME"image/png"(), "png"), (MIME"image/jpeg"(), "jpg"))
+  for (mime, ext) in mime_pairs
     showable(mime, img) || continue
     path = joinpath(mktempdir(), "img.$ext") # cleaned up on Julia process exit
     open(path; write=true) do io

--- a/src/sweep.jl
+++ b/src/sweep.jl
@@ -14,7 +14,7 @@ end
 
 function (hpsweep::WandbHyperParameterSweep)(func, cfg,
                                              # For Compat with FluxTraining and other Integrations
-                                             logger=WandbLogger, args...; config = nothing,
+                                             logger=WandbLogger, args...; config=nothing,
                                              func_args=(), func_kwargs=(;), kwargs...)
   lg = logger(args...; tags=[hpsweep.sweep_tag], kwargs...)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,14 @@
-using Test, Wandb, PlotlyJS
+using Test
+using Wandb
+using PlotlyJS
+using PythonCall
 
 @testset "Wandb.Image" begin
   # Take a generic object that supports `show(io, MIME"image/png", img)`
   # and try to pass it to `Wandb.Image`.
   p1 = Plot(scatter(; x=1:10, y=2:11))
   img = Wandb.Image(p1)
-  @test img.format == "png"
+  @test pyconvert(Any, img.format) == "png"
 
   # Test error path
   @test_throws ErrorException Wandb.Image(["hi"])


### PR DESCRIPTION
The vast majority of the work to integrate PythonCall.jl has been done here https://github.com/avik-pal/Wandb.jl/pull/22.

Here are the changes that I make in this PR:
- Use conda to install all dependencies to avoid version issues with having pip and conda deps. 
- Limit protobuf to v3 (v4 appears to have compatibility issues, and I couldn't import wandb with it).
- Add FluxTraining.jl example 
- Fix Flux.jl, mpi examples
- Fix mime_pairs logic in Wandb.Image
- Fix the test by converting the pystring to a julia string

I did not add any extra tests, but all the examples run for me. 