### PR TITLE
Relax dependency requirements for `protobuf`.

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,6 +1,6 @@
 [deps]
 numpy = ""
 pillow = ""
-protobuf = "=3"
+protobuf = ">=3"
 python = ">=3.9"
 wandb = ">=0.13"


### PR DESCRIPTION
Relax dependency requirements for protobuf.

Within my usage of this package I have repeatedly encountered resolving issues with other python dependencies when using Wandb.jl in the same project.

Most often these stem from the requirement that `protobuf` has to have a version of _exactly_ `3`.

For me it seems fine to relax this requirement to `>=3` but it could / should maybe constrained to `>=3,<4` if there is any reason to do so.