### PR TITLE
Replaced erroneous call to "close" with "finish"

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -83,7 +83,7 @@ end
 Terminate the current run. For more details checkout `wandb.finish` (or
 `? Wandb.wandb.finish` in the Julia REPL).
 """
-Base.close(lg::WandbLogger; kwargs...) = lg.wrun.close(; kwargs...)
+Base.close(lg::WandbLogger; kwargs...) = lg.wrun.finish(; kwargs...)
 
 """
     save(lg::WandbLogger, args...; kwargs...)


### PR DESCRIPTION
It looks like in the switch from "finish" to "close", a bug was introduced. 
Switched back to "finish" so that WandbLogger can be properly closed. 