### PR TITLE
Fix python <--> julia string comparison in ongoing run warning

### DIFF
--- a/src/main.jl
+++ b/src/main.jl
@@ -33,7 +33,7 @@ function WandbLogger(; project, name=nothing, min_level=Info, step_increment=1,
   else
     wrun = wandb.init(; project, name, config, kwargs...)
   end
-  if !isnothing(name) && wrun.name != name
+  if !isnothing(name) && string(wrun.name) != name
     @warn "There is an ongoing wandb run. Please `close` the run before initializing a \
            new one."
   end


### PR DESCRIPTION
Currently there is always a warning that there is an ongoing run.
Reason is that `WandbLogger.wandb.name` is a `PythonCall.Core.Py`, and comparison with a julia string is always false.